### PR TITLE
Low effort shutdown fix

### DIFF
--- a/windows10/shutdown.txt
+++ b/windows10/shutdown.txt
@@ -7,5 +7,5 @@ DELAY 500
 STRING cmd
 ENTER
 DELAY 1000
-string shutdown -s -t 10
+STRING shutdown -s -t 10
 ENTER


### PR DESCRIPTION
Fix for this issue https://github.com/SeenKid/flipper-zero-bad-usb/issues/11

Basically windows 10 22h2 won't shutdown if the string word would be lowercase; also, here https://github.com/SeenKid/flipper-zero-bad-usb/blob/main/windows11/shutdown.txt STRING is also lowercase but I don't have win 11 around to test it so I didn't change windows 11 shutdown.txt

Here's what will happen on windows 10 22h2 if you try to use shutdown.txt with STRING word being lowercase
![image](https://github.com/user-attachments/assets/4e48cf43-7b1a-4d3d-b574-6b611e7d81fa)
